### PR TITLE
Fix random value helper and stray closing div

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -260,8 +260,12 @@ let stringToWords = (string) => {
     .split(' ');
 };
 // Outputs a random value in [val1, val2) or [0 val1( with one argument
-let randomValue = (val1, val2 = 0) => {
-  return val1 + Math.random() * (val2 - val1);
+let randomValue = (val1, val2 = null) => {
+  if (val2 === null) {
+    val2 = val1;
+    val1 = 0;
+  }
+  return Math.random() * (val2 - val1) + val1;
 };
 // Extracts unique values of the array
 let uniqueValues = (array) => {

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,5 @@
   <script src="web/js/vendors.js"></script>
   <!-- @endif -->
   <script src="web/js/bundle.js"></script>
-</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct the `randomValue` helper so single-argument calls return numbers in `[0, val)`
- remove an extra closing `div` from the HTML

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d19e962308321a416d21e66f78aca