### PR TITLE
Improve docs for building site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,28 @@ through body language.
 Various female voices extracted using http://youglish.com.
 Final recording of the poem by the author. Background music: [Fantasia by Robert Johnson][2]
 
+## Setup
+
+Install the Node dependencies and start a development server using `gulp`:
+
+```bash
+npm install
+gulp
+```
+
+The command above builds the site in `dev/` and launches a local web server with live reload.
+
+To create a production build run:
+
+```bash
+npm run deploy
+```
+
+This executes `gulp deploy` and outputs the site in the `dist/` directory.
+
+### GitHub Pages
+
+Commit the contents of the generated `dist/` folder and push them to your repository. Then enable GitHub Pages from your repository settings by selecting the `dist/` directory on your main branch as the publishing source.
+
 [1]:http://www.scottishpoetrylibrary.org.uk/poetry/poems/anne-hathaway
 [2]:https://open.spotify.com/track/5tJ1L1iFP2WRMBPN1gdlTG

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Sound art for lovers",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "deploy": "gulp deploy"
   },
   "author": "Jean-Philippe Drecourt",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- outline how to install dependencies and run gulp
- add npm script for deploying
- document building a production site and enabling GitHub Pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b18dac48321a47a18a7c9a3318f