### PR TITLE
Fix docs to match build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The command above builds the site in `dev/` and launches a local web server with
 To create a production build run:
 
 ```bash
-npm run deploy
+npm run build
 ```
 
 This executes `gulp deploy` and outputs the site in the `docs/` directory.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ The command above builds the site in `dev/` and launches a local web server with
 To create a production build run:
 
 ```bash
-npm run deploy
+npm run build
 ```
 
 This executes `gulp deploy` and outputs the site in the `docs/` directory.


### PR DESCRIPTION
## Summary
- use `npm run build` in README and docs
- keep GitHub Pages workflow using the same build command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d30c439748321ab2be170d5bdc37d