### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const gulp = require('gulp');
 const { src, dest, series, parallel, watch } = gulp;
-const gutil = require('gulp-util');
+const log = require('fancy-log');
+const PluginError = require('plugin-error');
 const browserify = require('browserify');
 const source = require('vinyl-source-stream');
 const buffer = require('vinyl-buffer');
@@ -92,7 +93,9 @@ function bundleApp(isProduction) {
   if (!isProduction && scriptsCount === 1) {
     browserify({ require: dependencies, debug: true })
       .bundle()
-      .on('error', gutil.log)
+      .on('error', function(err) {
+        log(new PluginError('bundleApp', err));
+      })
       .pipe(source('vendors.js'))
       .pipe(dest('./dev/web/js/'));
   }
@@ -107,7 +110,7 @@ function bundleApp(isProduction) {
     .transform('babelify', { presets: ['es2015'] })
     .bundle()
     .on('error', function(error) {
-      gutil.log(error);
+      log(new PluginError('bundleApp', error));
       this.emit('end');
     })
     .pipe(source('bundle.js'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "gulp-preprocess": "^2.0.0",
         "gulp-sass": "^5.1.0",
         "gulp-sym": "0.0.14",
-        "gulp-util": "^3.0.7",
+        "fancy-log": "^2.0.0",
+        "plugin-error": "^1.0.1",
         "gulp-webserver": "^0.9.1",
         "sass": "^1.69.5",
         "vinyl-source-stream": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "gulp-sass": "^5.1.0",
     "sass": "^1.69.5",
     "gulp-sym": "0.0.14",
-    "gulp-util": "^3.0.7",
+    "fancy-log": "^2.0.0",
+    "plugin-error": "^1.0.1",
     "gulp-webserver": "^0.9.1",
     "vinyl-source-stream": "^1.1.0",
     "vinyl-buffer": "^1.0.1"


### PR DESCRIPTION
## Summary
- drop deprecated `gulp-util`
- use `fancy-log` for logging
- use `plugin-error` for gulp error handling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d30d200c083219d700b37a63f3892